### PR TITLE
_content/blog: remove duplicated content element

### DIFF
--- a/_content/blog/default.tmpl
+++ b/_content/blog/default.tmpl
@@ -1,5 +1,5 @@
 {{define "layout"}}
-<div id="blog"><div id="content">
+<div id="blog">
   <div id="content">
 
     <div class="Article" data-slug="{{.URL}}">


### PR DESCRIPTION
This PR is a draft.

---

This change removes duplicated content element.
I've confirmed that the number of closing element is correct.